### PR TITLE
Implemented canViewPremiumNFTs function

### DIFF
--- a/FashionPlatform/NFTFashionPlatformCore.sol
+++ b/FashionPlatform/NFTFashionPlatformCore.sol
@@ -106,6 +106,27 @@ contract NFTFashionPlatformCore is ERC721URIStorage, Ownable {
     
 }
  function canViewPremiumNFTs(address artist, address viewer) public view returns (bool) {
-  
+    
+    if (!artists[artist].registered) {
+        return false;
     }
+
+    if (viewer == artist) {
+        return true;
+    }
+    
+    uint256[] memory membershipNFTs = artistMembershipNFTs[artist];
+
+    if (membershipNFTs.length == 0) {
+        return false;
+    }
+    
+    for (uint256 i = 0; i < membershipNFTs.length; i++) {
+        if (ownerOf(membershipNFTs[i]) == viewer) {
+            return true;
+        }
+    }
+    
+    return false;
 }
+    }


### PR DESCRIPTION
Resolves #14 .

Implemented the canViewPremiumNFTs function.
The function checks if the artist is registered, if the viewer viewing the NFT is the artist himself, verifies that the viewer holds a valid membership NFT and returns a boolean indicating whether the user can view premium designs.


- [x] I have read all the contributor guidelines for the repo.
