### PR TITLE
Update NFTFashionPlatformCore.sol

### DIFF
--- a/FashionPlatform/NFTFashionPlatformCore.sol
+++ b/FashionPlatform/NFTFashionPlatformCore.sol
@@ -105,7 +105,14 @@ contract NFTFashionPlatformCore is ERC721URIStorage, Ownable {
     function mintMembershipNFT(address artist) external {
     
 }
- function canViewPremiumNFTs(address artist, address viewer) public view returns (bool) {
-  
+function canViewPremiumNFTs(address artist, address viewer) public view returns (bool) {
+    uint256[] memory memberships = artistMembershipNFTs[artist];
+
+    for (uint256 i = 0; i < memberships.length; i++) {
+        if (ownerOf(memberships[i]) == viewer) {
+            return true;
+        }
     }
+
+    return false;
 }


### PR DESCRIPTION
#14 resolve

Resolves #Implement canViewPremiumNFTs Function

## Description

Checks if a viewer owns any membership NFT associated with the given artist.
If ownership is found, returns true; otherwise, false.

> What is the purpose of this pull request?
Verify that the viewer holds a valid membership NFT.
Implement logic to allow or restrict access based on ownership.
Return a boolean indicating whether the user can view premium designs.

