### PR TITLE
Update NFTFashionPlatformCore.sol

### DIFF
--- a/FashionPlatform/NFTFashionPlatformCore.sol
+++ b/FashionPlatform/NFTFashionPlatformCore.sol
@@ -102,8 +102,13 @@ contract NFTFashionPlatformCore is ERC721URIStorage, Ownable {
         communityPosts[_tokenId].push(_content);
         emit CommunityPostAdded(_tokenId, _content);
     }
-    function mintMembershipNFT(address artist) external {
-    
+      function mintMembershipNFT(address artist) external {
+    require(artists[artist].registered, "Artist not registered.");
+      uint256 tokenId = tokenCounter;
+    _mint(msg.sender, tokenId);
+    artistMembershipNFTs[artist].push(tokenId);
+    tokenCounter++;
+    emit MembershipNFTMinted(artist, msg.sender, tokenId);
 }
  function canViewPremiumNFTs(address artist, address viewer) public view returns (bool) {
   


### PR DESCRIPTION
#13  resolves 

Implement mintMembershipNFT Function

Resolves #Abscense of proper function . Makes Mint function which is very useful to users to grant them special priviledges 

## mintMembershipNFT Function:

Mints a membership NFT for an artist.

Stores the NFT in artistMembershipNFTs[artist] for access control.

Emits an event upon minting.


> What is the purpose of this pull request?
The mintMembershipNFT function is currently incomplete. This function should allow users to mint an NFT that grants them special privileges on the platform. The missing implementation should:

## Live Demo (if any)
> If applicable, include a link or screenshots of a live demo

## Checkout
- [ ] I have read all the contributor guidelines for the repo.
