### PR TITLE
Implemented canViewPremiumNFTs Function

### DIFF
--- a/FashionPlatform/NFTFashionPlatformCore.sol
+++ b/FashionPlatform/NFTFashionPlatformCore.sol
@@ -106,6 +106,17 @@ contract NFTFashionPlatformCore is ERC721URIStorage, Ownable {
     
 }
  function canViewPremiumNFTs(address artist, address viewer) public view returns (bool) {
-  
+          if (artist == viewer) {
+        return true;
+    }
+    
+    uint256[] memory membershipNFTs = artistMembershipNFTs[artist];
+    for (uint i = 0; i < membershipNFTs.length; i++) {
+        if (ownerOf(membershipNFTs[i]) == viewer) {
+            return true;
+        }
+    }
+    
+    return false;
     }
 }


### PR DESCRIPTION
Implemented the incomplete function canViewPremiumNFTs in NFTFashionPlatformCore.sol  contract

This PR completes the canViewPremiumNFTs function by adding logic to check if a viewer has access to premium designs. It first allows the artist to view their own premium NFTs. Then, it checks if the viewer owns any valid membership NFTs linked to the artist. If the viewer holds a membership NFT, they get access; otherwise, access is denied as it basically a boolean value.

Resolves #14 