### PR TITLE
Complete singleUploadDesign Function

### DIFF
--- a/FashionPlatform/NFTFashionPlatformCore.sol
+++ b/FashionPlatform/NFTFashionPlatformCore.sol
@@ -72,7 +72,15 @@ contract NFTFashionPlatformCore is ERC721URIStorage, Ownable {
         );
         require(_price > 0, "Price must be greater than 0.");
 
+       uint256 tokenID = tokenCounter;
+       tokenCounter++;
+       _mint(msg.sender,tokenID);
+       _setTokenURI(tokenID,_tokenURI);
 
+       designs[tokenID]=Design(tokenID,_tokenURI,msg.sender,_category,_designType,_price,0);
+       userOwnedDesigns[msg.sender].push(tokenID);
+       
+       emit  DesignUploaded(tokenID, msg.sender, _category, _designType);
     }
 
     function buyDesign(uint256 _tokenId) external payable {


### PR DESCRIPTION
Implemented the incomplete singleUploadDesign function by adding the requied functionalities in it

This PR completes the incomplete singleUploadDesign function, allowing registered artists to mint and upload their NFT designs. The function now verifies all necessary conditions, including checking valid categories (General or Premium) and design types (Clothing or Fabric). It mints a new NFT, assigns ownership, and correctly updates the designs mapping and userOwnedDesigns list. Additionally, the tokenCounter is now incremented properly, preventing any token ID mismanagement and finally it emits the DesignUploaded event at last.

Resolves #12 
