### PR TITLE
Added the mintMembershipNFT function

### DIFF
--- a/FashionPlatform/NFTFashionPlatformCore.sol
+++ b/FashionPlatform/NFTFashionPlatformCore.sol
@@ -103,8 +103,13 @@ contract NFTFashionPlatformCore is ERC721URIStorage, Ownable {
         emit CommunityPostAdded(_tokenId, _content);
     }
     function mintMembershipNFT(address artist) external {
-    
-}
+        require(artists[artist].registered, "Artist must be registered");
+        uint256 tokenId = tokenCounter;
+        _safeMint(artist, tokenId);
+        artistMembershipNFTs[artist].push(tokenId);
+        emit MembershipNFTMinted(artist, msg.sender, tokenId);
+        tokenCounter++;
+    }
  function canViewPremiumNFTs(address artist, address viewer) public view returns (bool) {
   
     }


### PR DESCRIPTION
Resolves #13 

## Description
- The function first requires that the provided artist is a registered artist.
- A new NFT is minted to the artist's address with the current tokenCounter as the token ID.
- The minted token ID is added to the artistMembershipNFTs mapping for tracking.
- The MembershipNFTMinted event is emitted with the artist, the minter (caller), and the token ID.
- Finally, the tokenCounter is increased for future mints.


## Checkout
- [x] I have read all the contributor guidelines for the repo.
- [x] Implement NFT minting logic for membership.
- [x] Ensure proper tracking in artistMembershipNFTs.
- [x] Emit a MembershipNFTMinted event.