### PR TITLE
Update hello_world_corrected.py

### DIFF
--- a/hello_world.py
+++ b/hello_world.py
@@ -2,15 +2,16 @@ from genlayer import *
 
 @gl.contract
 class MyContract:
-    variable: str
+    variable: gl.Storage[str]
 
     def __init__(self):
-        self.variable = "hello"
+        gl.initialize(self)
+        self.variable.set("hello")
 
     @gl.public.view
     def read_method(self) -> str:
-        return self.variable
+        return self.variable.get()
 
     @gl.public.write
-    def write_method(self,new_value:str) -> None:
-        self.variable = "world"
+    def write_method(self, new_value: str) -> None:
+        self.variable.set(new_value)


### PR DESCRIPTION
Resolves #60 

## Description

> What is the purpose of this pull request?
Corrected Version :- It made me get to know that the compilation error arises because state variables in GenLayer must be declared using the framework's specific storage mechanisms, not regular instance variables.
Additions:- Added explicit storing of variable in storage , explicit initialization and use of get,set functions.

## Checkout
- ✅ I have read all the contributor guidelines for the repo.
