### PR TITLE
Implemented enum for Shipment Status 

### DIFF
--- a/FashionPlatform/NFTFashionPlatformCore.sol
+++ b/FashionPlatform/NFTFashionPlatformCore.sol
@@ -103,8 +103,13 @@ contract NFTFashionPlatformCore is ERC721URIStorage, Ownable {
         emit CommunityPostAdded(_tokenId, _content);
     }
     function mintMembershipNFT(address artist) external {
-    
-}
+        require(artists[artist].registered, "Artist must be registered");
+        uint256 tokenId = tokenCounter;
+        _safeMint(artist, tokenId);
+        artistMembershipNFTs[artist].push(tokenId);
+        emit MembershipNFTMinted(artist, msg.sender, tokenId);
+        tokenCounter++;
+    }
  function canViewPremiumNFTs(address artist, address viewer) public view returns (bool) {
   
     }


### PR DESCRIPTION
Resolves #2 

## Description
- Enum for Shipment Status:
  - The uint256 is replaced by ShipmentStatus enum. Functions now use ShipmentStatus.PENDING, ShipmentStatus.IN_TRANSIT, and ShipmentStatus.DELIVERED accordingly.
- Estimated Delivery Time:
   - Added estimatedDeliveryTime, createShipment now accepts this as another parameter.


## Checkout
- [x] I have read all the contributor guidelines for the repo.
