### PR TITLE
implemented the function canViewPremium

### DIFF
--- a/FashionPlatform/NFTFashionPlatformCore.sol
+++ b/FashionPlatform/NFTFashionPlatformCore.sol
@@ -106,6 +106,15 @@ contract NFTFashionPlatformCore is ERC721URIStorage, Ownable {
     
 }
  function canViewPremiumNFTs(address artist, address viewer) public view returns (bool) {
+    require(artistMembershipNFTs[artist].length > 0, "Artist has no membership NFTs");
+  for (uint256 i = 0; i < artistMembershipNFTs[artist].length; i++) {
+        uint256 membershipTokenId = artistMembershipNFTs[artist][i];
+        
+        if (ownerOf(membershipTokenId) == viewer) {
+            return true; // Viewer holds a valid membership NFT
+        }
+    }
+    return false;
   
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "contract-combat-web3",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
Issue #14 

## Description
1)the canViewPremium function enables us to check if the user has the required membership NFT to view premium designs of an artist.
2) first it checks if the artist has any membership NFTs. If he doesnt then the appropriate message is shown.
3)If the artist has membership NFTs then we use a for loop to check if the user owns it.
4) if the user owns it then he can view the premium designs and true is returned, if he doesn't, false is returned.

> What is the purpose of this pull request?

## Live Demo (if any)
> If applicable, include a link or screenshots of a live demo

## Checkout
- [x] I have read all the contributor guidelines for the repo.
