### PR TITLE
implemented canViewPremiumNFT

### DIFF
--- a/FashionPlatform/NFTFashionPlatformCore.sol
+++ b/FashionPlatform/NFTFashionPlatformCore.sol
@@ -106,6 +106,13 @@ contract NFTFashionPlatformCore is ERC721URIStorage, Ownable {
     
 }
  function canViewPremiumNFTs(address artist, address viewer) public view returns (bool) {
-  
+    uint256[] memory membershipTokens = artistMembershipNFTs[artist];
+    for (uint256 i = 0; i < membershipTokens.length; i++) {
+        // Check if the viewer owns this membership NFT.
+        if (ownerOf(membershipTokens[i]) == viewer) {
+            return true;
+        }
     }
+    return false;
+}
 }


### PR DESCRIPTION
Resolves #14

## Description
This PR implements the canViewPremiumNFTs function, allowing access control for premium NFT designs based on membership NFT ownership. The function checks whether a viewer holds a valid membership NFT associated with an artist, determining if they can access premium designs.


## Checkout
- [ ] I have read all the contributor guidelines for the repo.
